### PR TITLE
Optimize Dockerfile layers and clean up config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,16 +58,14 @@ RUN set -eux; \
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # Set up app dir and ownership
-RUN usermod -u 1000 www-data && groupmod -g 1000 www-data
-RUN mkdir -p /etc/caddy /data/caddy /var/www/html /var/www/.composer /etc/php \
+RUN usermod -u 1000 www-data && groupmod -g 1000 www-data \
+    && mkdir -p /etc/caddy /data/caddy /var/www/html /var/www/.composer /etc/php \
     && chown -R www-data:www-data /var/www /data /etc/caddy \
     && chown root:root /etc/php
 
+# Copy configuration files and entrypoint
 COPY --chown=www-data:www-data common/Caddyfile.template /etc/caddy/Caddyfile.template
-COPY common/entrypoint-base.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
-
-# Copy PHP configuration from common
+COPY --chmod=755 common/entrypoint-base.sh /usr/local/bin/entrypoint.sh
 COPY common/conf/app.ini /usr/local/etc/php/conf.d/zz-app.ini
 COPY common/conf/opcache.ini /usr/local/etc/php/conf.d/zz-opcache.ini
 
@@ -77,10 +75,7 @@ ENV CADDY_LOG_OUTPUT=stdout \
 
 WORKDIR /var/www/html
 
-EXPOSE 80
-EXPOSE 443
-EXPOSE 443/udp
-EXPOSE 2019
+EXPOSE 80 443 443/udp 2019
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
@@ -92,11 +87,9 @@ FROM base AS dev
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     mkcert \
- && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN install-php-extensions xdebug
-
-RUN curl -L -o /usr/local/bin/mhsendmail \
+ && apt-get clean && rm -rf /var/lib/apt/lists/* \
+ && install-php-extensions xdebug \
+ && curl -L -o /usr/local/bin/mhsendmail \
     https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
  && chmod +x /usr/local/bin/mhsendmail
 
@@ -104,9 +97,7 @@ RUN curl -L -o /usr/local/bin/mhsendmail \
 COPY common/conf/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
 COPY common/conf/xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug.ini
 COPY common/conf/disable-opcache.ini /usr/local/etc/php/conf.d/zz-opcache.ini
-
-COPY common/entrypoint-dev.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY --chmod=755 common/entrypoint-dev.sh /usr/local/bin/entrypoint.sh
 
 ENV SENDMAIL_PATH=/usr/local/bin/mhsendmail \
     MAGENTO_RUN_MODE=developer \

--- a/common/conf/disable-opcache.ini
+++ b/common/conf/disable-opcache.ini
@@ -1,6 +1,3 @@
 ; Disable OPcache for development
 opcache.enable=0
 opcache.enable_cli=0
-; optionally harden: disable validating and remote config
-opcache.validate_timestamps=0
-opcache.restrict_api=0


### PR DESCRIPTION
## Description

Reduces Docker image layers by consolidating RUN commands and using COPY --chmod. Removes dead config in disable-opcache.ini.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🔧 Maintenance (refactoring, dependencies, etc.)

## Related Issues

N/A

## Changes Made

**Dockerfile (base stage):**
- Merge `usermod/groupmod` + `mkdir/chown` into single RUN
- Use `COPY --chmod=755` for entrypoint instead of separate `RUN chmod`
- Combine 4 EXPOSE statements into one line

**Dockerfile (dev stage):**
- Merge apt-get, install-php-extensions, and mhsendmail curl into single RUN
- Use `COPY --chmod=755` for entrypoint

**Config cleanup:**
- Remove `validate_timestamps` and `restrict_api` from disable-opcache.ini (no effect when opcache disabled)

**Result:** 5 fewer layers, 12 fewer lines, identical functionality.

## Testing

### Manual Testing

- [x] Built Docker images locally
- [ ] Tested with Magento 2 installation
- [ ] Verified PHP extensions are working
- [ ] Tested development features (Xdebug, etc.)

### Test Commands Run

```bash
hadolint Dockerfile  # Pre-existing warnings only (DL3008, DL3006)
shellcheck common/*.sh bin/build-images  # Pass
yamllint .  # Pass
```

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [x] My code follows the project's coding standards
- [x] I have run `hadolint Dockerfile` and fixed any issues
- [x] I have run `shellcheck` on any shell scripts I modified
- [ ] I have updated the documentation if necessary
- [x] My changes don't introduce new warnings or errors
- [x] I have tested my changes locally

## Screenshots (if applicable)

N/A

## Additional Notes

Pre-existing hadolint warnings (DL3008 apt version pinning, DL3006 image tagging) remain—fixing those would add complexity without meaningful benefit for this use case.
