### PR TITLE
Bump FrankenPHP to 1.11.3, add PHP 8.5, implement dev UID/GID and mkcert

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY: docker.io
   IMAGE_NAME: mohelmrabet/magento-frankenphp
-  FRANKENPHP_VERSION: '1.10.1'
+  FRANKENPHP_VERSION: '1.11.3'
 
 permissions:
   contents: read
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ['8.2', '8.3', '8.4']
+        php_version: ['8.2', '8.3', '8.4', '8.5']
         target: ['base', 'dev']
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY: docker.io
   IMAGE_NAME: mohelmrabet/magento-frankenphp
-  FRANKENPHP_VERSION: '1.11.3'
+  FRANKENPHP_VERSION: '1.12.7'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'config'
           scan-ref: '.'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,4 +76,5 @@ jobs:
         with:
           scan-type: 'config'
           scan-ref: '.'
-        continue-on-error: true
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #   docker build --target dev -t magento-frankenphp:dev .
 
 ARG PHP_VERSION=8.4
-ARG FRANKENPHP_VERSION=1.10.1
+ARG FRANKENPHP_VERSION=1.11.3
 
 FROM dunglas/frankenphp:${FRANKENPHP_VERSION}-php${PHP_VERSION} AS base
 LABEL maintainer="Mohamed El Mrabet <contact@cleatsquad.dev>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 # Set up app dir and ownership
 RUN usermod -u 1000 www-data && groupmod -g 1000 www-data
 RUN mkdir -p /etc/caddy /data/caddy /var/www/html /var/www/.composer /etc/php \
-    && chown -R www-data:www-data /var/www /data /etc/caddy \
+    && chown -R www-data:www-data /var/www /data /etc/caddy /config/caddy \
     && chown root:root /etc/php
 
 COPY --chown=www-data:www-data common/Caddyfile.template /etc/caddy/Caddyfile.template
@@ -77,6 +77,8 @@ ENV CADDY_LOG_OUTPUT=stdout \
 
 WORKDIR /var/www/html
 
+USER www-data
+
 EXPOSE 80
 EXPOSE 443
 EXPOSE 443/udp
@@ -89,6 +91,14 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -f http://localhost/health.php || exit 1
 
 FROM base AS dev
+
+# The dev entrypoint needs root at startup to remap www-data to the host's
+# UID/GID and install mkcert's CA, then drops to www-data via gosu before
+# starting FrankenPHP (see common/entrypoint-dev.sh) -- the same pattern used
+# by official images like postgres/mysql. The dev image is never used as a
+# production runtime target, only the base target is.
+# trivy:ignore:AVD-DS-0002
+USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #   docker build --target dev -t magento-frankenphp:dev .
 
 ARG PHP_VERSION=8.4
-ARG FRANKENPHP_VERSION=1.11.3
+ARG FRANKENPHP_VERSION=1.12.7
 
 FROM dunglas/frankenphp:${FRANKENPHP_VERSION}-php${PHP_VERSION} AS base
 LABEL maintainer="Mohamed El Mrabet <contact@cleatsquad.dev>"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://hub.docker.com/r/mohelmrabet/magento-frankenphp"><img src="https://img.shields.io/docker/pulls/mohelmrabet/magento-frankenphp.svg?logo=docker" alt="Docker Pulls" /></a>
   <img src="https://img.shields.io/badge/magento-2.4.x-orange.svg?logo=magento" alt="Magento 2.4.x" />
   <img src="https://img.shields.io/badge/php-8.2%20|%208.3%20|%208.4%20|%208.5-blue.svg?logo=php" alt="PHP Versions" />
-  <img src="https://img.shields.io/badge/frankenphp-1.11-purple.svg" alt="FrankenPHP 1.11" />
+  <img src="https://img.shields.io/badge/frankenphp-1.12-purple.svg" alt="FrankenPHP 1.12" />
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License MIT" /></a>
 </p>
 
@@ -26,14 +26,14 @@
 
 | Tag | PHP | Type | Description |
 |-----|-----|------|-------------|
-| `php8.5-fp1.11.3-base` | 8.5 | Base | Production ready |
-| `php8.5-fp1.11.3-dev` | 8.5 | Dev | With Xdebug |
-| `php8.4-fp1.11.3-base` | 8.4 | Base | Production ready |
-| `php8.4-fp1.11.3-dev` | 8.4 | Dev | With Xdebug |
-| `php8.3-fp1.11.3-base` | 8.3 | Base | Production ready |
-| `php8.3-fp1.11.3-dev` | 8.3 | Dev | With Xdebug |
-| `php8.2-fp1.11.3-base` | 8.2 | Base | Production ready (EOL 2026-12-31, upgrade recommended) |
-| `php8.2-fp1.11.3-dev` | 8.2 | Dev | With Xdebug (EOL 2026-12-31, upgrade recommended) |
+| `php8.5-fp1.12.7-base` | 8.5 | Base | Production ready |
+| `php8.5-fp1.12.7-dev` | 8.5 | Dev | With Xdebug |
+| `php8.4-fp1.12.7-base` | 8.4 | Base | Production ready |
+| `php8.4-fp1.12.7-dev` | 8.4 | Dev | With Xdebug |
+| `php8.3-fp1.12.7-base` | 8.3 | Base | Production ready |
+| `php8.3-fp1.12.7-dev` | 8.3 | Dev | With Xdebug |
+| `php8.2-fp1.12.7-base` | 8.2 | Base | Production ready (EOL 2026-12-31, upgrade recommended) |
+| `php8.2-fp1.12.7-dev` | 8.2 | Dev | With Xdebug (EOL 2026-12-31, upgrade recommended) |
 | `latest` | 8.4 | Base | Default |
 | `base` | 8.4 | Base | Alias |
 | `dev` | 8.4 | Dev | Alias |
@@ -45,7 +45,7 @@
 ```yaml
 services:
   app:
-    image: mohelmrabet/magento-frankenphp:php8.4-fp1.11.3-dev
+    image: mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-dev
     environment:
       - USER_ID=1000
       - GROUP_ID=1000
@@ -59,7 +59,7 @@ services:
 ### Production
 
 ```dockerfile
-FROM mohelmrabet/magento-frankenphp:php8.4-fp1.11.3-base
+FROM mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-base
 
 COPY --chown=www-data:www-data . /var/www/html/
 
@@ -73,7 +73,7 @@ RUN bin/magento setup:static-content:deploy -f
 
 ### Base Image
 - ✅ PHP 8.2, 8.3, 8.4, 8.5
-- ✅ FrankenPHP 1.11.3
+- ✅ FrankenPHP 1.12.7
 - ✅ All Magento PHP extensions
 - ✅ Composer 2
 - ✅ OPcache optimized

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <p align="center">
   <a href="https://hub.docker.com/r/mohelmrabet/magento-frankenphp"><img src="https://img.shields.io/docker/pulls/mohelmrabet/magento-frankenphp.svg?logo=docker" alt="Docker Pulls" /></a>
   <img src="https://img.shields.io/badge/magento-2.4.x-orange.svg?logo=magento" alt="Magento 2.4.x" />
-  <img src="https://img.shields.io/badge/php-8.2%20|%208.3%20|%208.4-blue.svg?logo=php" alt="PHP Versions" />
-  <img src="https://img.shields.io/badge/frankenphp-1.10-purple.svg" alt="FrankenPHP 1.10" />
+  <img src="https://img.shields.io/badge/php-8.2%20|%208.3%20|%208.4%20|%208.5-blue.svg?logo=php" alt="PHP Versions" />
+  <img src="https://img.shields.io/badge/frankenphp-1.11-purple.svg" alt="FrankenPHP 1.11" />
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License MIT" /></a>
 </p>
 
@@ -26,12 +26,14 @@
 
 | Tag | PHP | Type | Description |
 |-----|-----|------|-------------|
-| `php8.4-fp1.10.1-base` | 8.4 | Base | Production ready |
-| `php8.4-fp1.10.1-dev` | 8.4 | Dev | With Xdebug |
-| `php8.3-fp1.10.1-base` | 8.3 | Base | Production ready |
-| `php8.3-fp1.10.1-dev` | 8.3 | Dev | With Xdebug |
-| `php8.2-fp1.10.1-base` | 8.2 | Base | Production ready |
-| `php8.2-fp1.10.1-dev` | 8.2 | Dev | With Xdebug |
+| `php8.5-fp1.11.3-base` | 8.5 | Base | Production ready |
+| `php8.5-fp1.11.3-dev` | 8.5 | Dev | With Xdebug |
+| `php8.4-fp1.11.3-base` | 8.4 | Base | Production ready |
+| `php8.4-fp1.11.3-dev` | 8.4 | Dev | With Xdebug |
+| `php8.3-fp1.11.3-base` | 8.3 | Base | Production ready |
+| `php8.3-fp1.11.3-dev` | 8.3 | Dev | With Xdebug |
+| `php8.2-fp1.11.3-base` | 8.2 | Base | Production ready (EOL 2026-12-31, upgrade recommended) |
+| `php8.2-fp1.11.3-dev` | 8.2 | Dev | With Xdebug (EOL 2026-12-31, upgrade recommended) |
 | `latest` | 8.4 | Base | Default |
 | `base` | 8.4 | Base | Alias |
 | `dev` | 8.4 | Dev | Alias |
@@ -43,7 +45,7 @@
 ```yaml
 services:
   app:
-    image: mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-dev
+    image: mohelmrabet/magento-frankenphp:php8.4-fp1.11.3-dev
     environment:
       - USER_ID=1000
       - GROUP_ID=1000
@@ -57,7 +59,7 @@ services:
 ### Production
 
 ```dockerfile
-FROM mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-base
+FROM mohelmrabet/magento-frankenphp:php8.4-fp1.11.3-base
 
 COPY --chown=www-data:www-data . /var/www/html/
 
@@ -70,8 +72,8 @@ RUN bin/magento setup:static-content:deploy -f
 ## Features
 
 ### Base Image
-- ✅ PHP 8.2, 8.3, 8.4
-- ✅ FrankenPHP 1.10.1
+- ✅ PHP 8.2, 8.3, 8.4, 8.5
+- ✅ FrankenPHP 1.11.3
 - ✅ All Magento PHP extensions
 - ✅ Composer 2
 - ✅ OPcache optimized
@@ -103,11 +105,36 @@ bcmath, gd, intl, mbstring, opcache, pdo_mysql, soap, xsl, zip, sockets, ftp, so
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `USER_ID` | `1000` | UID for www-data |
-| `GROUP_ID` | `1000` | GID for www-data |
+| `USER_ID` | `1000` | UID www-data is remapped to at startup (matches host file ownership on bind mounts) |
+| `GROUP_ID` | `1000` | GID www-data is remapped to at startup |
 | `MAGENTO_RUN_MODE` | `developer` | Magento mode |
 | `SERVER_NAME` | `localhost` | Server hostname for SSL |
-| `ENABLE_SSL_DEV` | `true` | Enable self-signed SSL |
+| `ENABLE_SSL_DEV` | `true` | Generate a locally-trusted certificate with mkcert at startup |
+| `CADDY_TLS_CONFIG` | *(auto)* | Set explicitly to skip mkcert and use `internal` or your own `cert key` paths |
+| `CAROOT` | *(mkcert default)* | Path to a shared mkcert CA (see below) so generated certs are trusted by the host |
+
+### Trusted local HTTPS (mkcert)
+
+On startup, the dev image generates a TLS certificate for `SERVER_NAME` using
+[mkcert](https://github.com/FiloSottile/mkcert), stored in the `/data/caddy/mkcert`
+volume. By default this uses a CA generated inside the container, which your
+host browser won't trust yet — you'll still see a warning once, and can
+inspect/accept it manually.
+
+To make the browser trust it automatically, share your host's mkcert CA with
+the container:
+
+```bash
+./bin/setup-ssl
+```
+
+This installs mkcert's CA in your host trust stores and prints the
+`docker-compose.yml` volume/env snippet to mount that CA into the container
+(`CAROOT`), so the container signs its certificate with the same CA the host
+already trusts. Restart the container afterwards.
+
+Set `ENABLE_SSL_DEV=false` or `CADDY_TLS_CONFIG=internal` to fall back to
+Caddy's built-in self-signed TLS instead.
 
 ## Xdebug Configuration (Dev)
 

--- a/bin/build-images
+++ b/bin/build-images
@@ -4,7 +4,7 @@ set -e
 IMAGE="mohelmrabet/magento-frankenphp"
 VERSIONS="8.2 8.3 8.4 8.5"
 DOCKERHUB_TOKEN=''
-FP="1.11.3"
+FP="1.12.7"
 
 build_all() {
     echo "🔨 Building all PHP versions..."

--- a/bin/build-images
+++ b/bin/build-images
@@ -2,9 +2,9 @@
 set -e
 
 IMAGE="mohelmrabet/magento-frankenphp"
-VERSIONS="8.2 8.3 8.4"
+VERSIONS="8.2 8.3 8.4 8.5"
 DOCKERHUB_TOKEN=''
-FP="1.10.1"
+FP="1.11.3"
 
 build_all() {
     echo "🔨 Building all PHP versions..."
@@ -124,7 +124,7 @@ case "$1" in
     *)
         echo "Usage: $0 {build|push|latest|push-readme|release|list}"
         echo ""
-        echo "  build       - Build all PHP versions (8.2, 8.3, 8.4)"
+        echo "  build       - Build all PHP versions (${VERSIONS})"
         echo "  push        - Push all PHP versions to Docker Hub"
         echo "  latest      - Tag and push latest tags"
         echo "  push-readme - Push README.md to Docker Hub"

--- a/bin/setup-ssl
+++ b/bin/setup-ssl
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Trust mkcert-issued dev certificates in the host's browsers.
+#
+# The dev container generates its TLS certificate with mkcert at startup.
+# For that certificate to show up as "trusted" (no browser warning), the
+# same mkcert local CA must be trusted on the HOST, and the container must
+# sign with that same CA rather than generating its own throwaway one.
+#
+# This script:
+#   1. Installs mkcert's local CA in the host's trust stores (mkcert -install)
+#   2. Prints the docker-compose volume mapping needed to share that CA with
+#      the container, so certs generated inside are trusted outside.
+set -e
+
+if ! command -v mkcert >/dev/null 2>&1; then
+    echo "❌ mkcert is not installed on this host."
+    echo ""
+    echo "Install it first:"
+    echo "  macOS:   brew install mkcert"
+    echo "  Linux:   see https://github.com/FiloSottile/mkcert#linux"
+    echo "  Windows: choco install mkcert"
+    exit 1
+fi
+
+echo "🔏 Installing mkcert local CA in host trust stores..."
+mkcert -install
+
+CAROOT="$(mkcert -CAROOT)"
+echo "✅ Local CA trusted. CAROOT: ${CAROOT}"
+echo ""
+echo "Share this CA with the dev container by mounting it and setting CAROOT"
+echo "so certificates generated inside the container are signed by the same"
+echo "CA your host already trusts:"
+echo ""
+echo "services:"
+echo "  app:"
+echo "    environment:"
+echo "      - CAROOT=/tmp/mkcert-caroot"
+echo "    volumes:"
+echo "      - ${CAROOT}:/tmp/mkcert-caroot:ro"
+echo ""
+echo "Then restart the container: docker compose up -d --force-recreate app"

--- a/common/entrypoint-dev.sh
+++ b/common/entrypoint-dev.sh
@@ -1,6 +1,29 @@
 #!/bin/bash
 set -e
 
+# --- UID/GID mapping -------------------------------------------------------
+# Aligns the www-data user inside the container with the host user so files
+# created by FrankenPHP/Composer/Magento CLI on the bind-mounted volume are
+# owned by the developer, not by an arbitrary container UID.
+USER_ID="${USER_ID:-1000}"
+GROUP_ID="${GROUP_ID:-1000}"
+
+if [ "$(id -u)" = "0" ]; then
+    CURRENT_UID=$(id -u www-data)
+    CURRENT_GID=$(id -g www-data)
+
+    if [ "$CURRENT_UID" != "$USER_ID" ] || [ "$CURRENT_GID" != "$GROUP_ID" ]; then
+        echo "👤 Remapping www-data to UID=${USER_ID} GID=${GROUP_ID} (was ${CURRENT_UID}:${CURRENT_GID})"
+        groupmod -o -g "$GROUP_ID" www-data
+        usermod -o -u "$USER_ID" www-data
+    fi
+
+    # Always align these container-owned dirs with www-data: needed even on
+    # the default 1000:1000 mapping, since /config/caddy ships root-owned and
+    # FrankenPHP now runs as www-data (dropped via gosu below).
+    chown -R www-data:www-data /var/www/.composer /etc/caddy /data/caddy /config/caddy
+fi
+
 # Process Caddyfile template
 # If a custom template is mounted, use it; otherwise use the default
 TEMPLATE_SOURCE="/etc/caddy/Caddyfile.template"
@@ -33,20 +56,58 @@ fi
 SSL_DOMAIN="${SERVER_NAME:-localhost}"
 SSL_DOMAIN=$(echo "$SSL_DOMAIN" | sed -E 's|^https?://||' | sed -E 's|:[0-9]+$||')
 
+# --- mkcert locally-trusted certificates ------------------------------------
+# When enabled (default), generate a certificate trusted by the host's local
+# CA via mkcert, so browsers don't show the "not secure" warning that comes
+# with Caddy's internal self-signed TLS. Falls back to internal TLS if mkcert
+# fails (e.g. the host CA was never installed via `bin/setup-ssl`) or if the
+# user already set CADDY_TLS_CONFIG explicitly.
+if [ "${ENABLE_SSL_DEV:-true}" = "true" ] && [ -z "$CADDY_TLS_CONFIG" ] && command -v mkcert >/dev/null 2>&1; then
+    CERT_DIR="/data/caddy/mkcert"
+    mkdir -p "$CERT_DIR"
+
+    if [ ! -f "$CERT_DIR/cert.pem" ] || [ ! -f "$CERT_DIR/key.pem" ]; then
+        echo "🔏 Generating mkcert certificate for: $SSL_DOMAIN"
+        if mkcert -install >/tmp/mkcert-install.log 2>&1 \
+            && mkcert -cert-file "$CERT_DIR/cert.pem" -key-file "$CERT_DIR/key.pem" \
+                "$SSL_DOMAIN" localhost 127.0.0.1 ::1 >/tmp/mkcert-gen.log 2>&1; then
+            echo "✅ mkcert certificate generated: $CERT_DIR"
+        else
+            echo "⚠️  mkcert failed, falling back to Caddy's internal TLS (see /tmp/mkcert-*.log)"
+            rm -f "$CERT_DIR/cert.pem" "$CERT_DIR/key.pem"
+        fi
+    fi
+
+    if [ -f "$CERT_DIR/cert.pem" ] && [ -f "$CERT_DIR/key.pem" ]; then
+        export CADDY_TLS_CONFIG="$CERT_DIR/cert.pem $CERT_DIR/key.pem"
+        [ "$(id -u)" = "0" ] && chown -R www-data:www-data "$CERT_DIR"
+    fi
+fi
+
 echo "🔐 SSL Mode: ${CADDY_TLS_CONFIG:-internal}"
 echo "🌐 Server Name: $SSL_DOMAIN"
 
-# If using internal TLS (default), Caddy will auto-generate self-signed certificates
 if [ "${CADDY_TLS_CONFIG:-internal}" = "internal" ]; then
     echo "📌 Using Caddy's internal TLS (self-signed certificates)"
     echo "   To trust certificates in your browser, either:"
     echo "   1. Accept the certificate manually (click Advanced → Proceed)"
-    echo "   2. Or run './bin/setup-ssl' on the host to generate trusted certificates"
+    echo "   2. Or run './bin/setup-ssl' on the host so mkcert's local CA is trusted"
+else
+    echo "📌 Using mkcert-issued certificate trusted by the host's local CA"
+fi
+
+# Drop root privileges before starting FrankenPHP, now that UID/GID mapping
+# and cert generation (which need root) are done.
+RUN_AS=""
+if [ "$(id -u)" = "0" ]; then
+    RUN_AS="gosu www-data"
 fi
 
 # Start FrankenPHP
 if [ $# -eq 0 ]; then
-    exec frankenphp run --config /etc/caddy/Caddyfile --watch
+    # shellcheck disable=SC2086
+    exec $RUN_AS frankenphp run --config /etc/caddy/Caddyfile --watch
 fi
 
-exec "$@"
+# shellcheck disable=SC2086
+exec $RUN_AS "$@"

--- a/docs/Caddyfile.md
+++ b/docs/Caddyfile.md
@@ -58,7 +58,7 @@ The Caddyfile template supports the following environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENABLE_SSL_DEV` | `true` | Enable/disable self-signed SSL certificate generation |
+| `ENABLE_SSL_DEV` | `true` | Enable/disable mkcert TLS certificate generation at startup |
 
 ### Examples
 
@@ -82,11 +82,11 @@ environment:
 
 ### Development (dev image)
 
-The dev image uses Caddy's built-in `tls internal` directive by default, which automatically generates self-signed SSL certificates.
+The dev image generates a TLS certificate at startup using [mkcert](https://github.com/FiloSottile/mkcert), signed by a CA generated inside the container. Falls back to Caddy's built-in `tls internal` directive (self-signed) if mkcert is unavailable or fails.
 
 #### Fixing `net::ERR_CERT_AUTHORITY_INVALID` Error
 
-By default, browsers don't trust the self-signed certificates. You have two options to fix this:
+By default, browsers don't trust the container's mkcert CA. You have two options to fix this:
 
 **Option 1: Trust the certificate manually in your browser (Quick)**
 
@@ -94,9 +94,9 @@ By default, browsers don't trust the self-signed certificates. You have two opti
 2. Click "Advanced" or "Show Details"
 3. Click "Proceed to site" or "Accept the Risk and Continue"
 
-**Option 2: Keep using internal TLS (Default)**
+**Option 2: Trust it automatically with `bin/setup-ssl`**
 
-By default, the container uses `tls internal` which generates self-signed certificates automatically. The only downside is the browser warning.
+Run `./bin/setup-ssl` on the host to install mkcert's CA in your host trust stores and mount it into the container (via `CAROOT`), so the container signs its certificate with the same CA the host already trusts. See the [Configuration Guide](configuration.md#trusted-local-https-mkcert).
 
 ### Production (base image)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,8 +17,9 @@ This guide covers all configuration options for the Magento FrankenPHP Docker im
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENABLE_SSL_DEV` | `true` | Enable self-signed SSL |
-| `CADDY_TLS_CONFIG` | (empty) | Custom TLS certificate paths |
+| `ENABLE_SSL_DEV` | `true` | Generate a locally-trusted certificate with mkcert at startup |
+| `CADDY_TLS_CONFIG` | (empty, auto) | Set explicitly to skip mkcert and use `internal` or your own `cert key` paths |
+| `CAROOT` | (mkcert default) | Path to a shared mkcert CA so generated certs are trusted by the host |
 
 ### Caddy Configuration
 
@@ -82,20 +83,39 @@ For detailed Xdebug configuration including IDE setup, CLI debugging, and troubl
 
 ## SSL Certificates
 
-### Development (Self-Signed)
+### Development (mkcert)
 
-The dev image uses Caddy's `tls internal` by default.
+On startup, the dev image generates a TLS certificate for `SERVER_NAME` using
+[mkcert](https://github.com/FiloSottile/mkcert), stored in the `/data/caddy/mkcert`
+volume. By default this uses a CA generated inside the container, which your
+host browser won't trust yet — you'll see a warning once, and can inspect/accept
+it manually.
 
 **Option 1: Accept browser warning**
 
 Click "Advanced" → "Proceed to site" in browser.
 
-**Option 2: Disable SSL**
+**Option 2: Trust the certificate automatically**
+
+Share your host's mkcert CA with the container:
+
+```bash
+./bin/setup-ssl
+```
+
+This installs mkcert's CA in your host trust stores and prints the
+`docker-compose.yml` volume/env snippet to mount that CA into the container
+(`CAROOT`), so the container signs its certificate with the same CA the host
+already trusts. Restart the container afterwards.
+
+**Option 3: Fall back to Caddy's internal self-signed TLS**
 
 ```yaml
 environment:
-  CADDY_TLS_CONFIG: ""
+  ENABLE_SSL_DEV: "false"
 ```
+
+or set `CADDY_TLS_CONFIG: internal` to skip mkcert explicitly.
 
 ### Production (Let's Encrypt)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,14 +6,14 @@ This guide explains how to use the Magento FrankenPHP Docker images.
 
 | Tag | PHP | Type | Description |
 |-----|-----|------|-------------|
-| `php8.5-fp1.11.3-base` | 8.5 | Base | Production ready |
-| `php8.5-fp1.11.3-dev` | 8.5 | Dev | With Xdebug |
-| `php8.4-fp1.11.3-base` | 8.4 | Base | Production ready |
-| `php8.4-fp1.11.3-dev` | 8.4 | Dev | With Xdebug |
-| `php8.3-fp1.11.3-base` | 8.3 | Base | Production ready |
-| `php8.3-fp1.11.3-dev` | 8.3 | Dev | With Xdebug |
-| `php8.2-fp1.11.3-base` | 8.2 | Base | Production ready (EOL 2026-12-31, upgrade recommended) |
-| `php8.2-fp1.11.3-dev` | 8.2 | Dev | With Xdebug (EOL 2026-12-31, upgrade recommended) |
+| `php8.5-fp1.12.7-base` | 8.5 | Base | Production ready |
+| `php8.5-fp1.12.7-dev` | 8.5 | Dev | With Xdebug |
+| `php8.4-fp1.12.7-base` | 8.4 | Base | Production ready |
+| `php8.4-fp1.12.7-dev` | 8.4 | Dev | With Xdebug |
+| `php8.3-fp1.12.7-base` | 8.3 | Base | Production ready |
+| `php8.3-fp1.12.7-dev` | 8.3 | Dev | With Xdebug |
+| `php8.2-fp1.12.7-base` | 8.2 | Base | Production ready (EOL 2026-12-31, upgrade recommended) |
+| `php8.2-fp1.12.7-dev` | 8.2 | Dev | With Xdebug (EOL 2026-12-31, upgrade recommended) |
 | `latest` | 8.4 | Base | Default |
 | `base` | 8.4 | Base | Alias |
 | `dev` | 8.4 | Dev | Alias |
@@ -25,7 +25,7 @@ This guide explains how to use the Magento FrankenPHP Docker images.
 ```yaml
 services:
   app:
-    image: mohelmrabet/magento-frankenphp:php8.4-fp1.11.3-dev
+    image: mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-dev
     environment:
       - USER_ID=1000
       - GROUP_ID=1000
@@ -39,7 +39,7 @@ services:
 ### Production
 
 ```dockerfile
-FROM mohelmrabet/magento-frankenphp:php8.4-fp1.11.3-base
+FROM mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-base
 
 COPY --chown=www-data:www-data . /var/www/html/
 
@@ -53,7 +53,7 @@ RUN bin/magento setup:static-content:deploy -f
 
 ### Base Image
 - ✅ PHP 8.2, 8.3, 8.4, 8.5
-- ✅ FrankenPHP 1.11.3
+- ✅ FrankenPHP 1.12.7
 - ✅ All Magento PHP extensions
 - ✅ Composer 2
 - ✅ OPcache optimized

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,12 +6,14 @@ This guide explains how to use the Magento FrankenPHP Docker images.
 
 | Tag | PHP | Type | Description |
 |-----|-----|------|-------------|
-| `php8.4-fp1.10.1-base` | 8.4 | Base | Production ready |
-| `php8.4-fp1.10.1-dev` | 8.4 | Dev | With Xdebug |
-| `php8.3-fp1.10.1-base` | 8.3 | Base | Production ready |
-| `php8.3-fp1.10.1-dev` | 8.3 | Dev | With Xdebug |
-| `php8.2-fp1.10.1-base` | 8.2 | Base | Production ready |
-| `php8.2-fp1.10.1-dev` | 8.2 | Dev | With Xdebug |
+| `php8.5-fp1.11.3-base` | 8.5 | Base | Production ready |
+| `php8.5-fp1.11.3-dev` | 8.5 | Dev | With Xdebug |
+| `php8.4-fp1.11.3-base` | 8.4 | Base | Production ready |
+| `php8.4-fp1.11.3-dev` | 8.4 | Dev | With Xdebug |
+| `php8.3-fp1.11.3-base` | 8.3 | Base | Production ready |
+| `php8.3-fp1.11.3-dev` | 8.3 | Dev | With Xdebug |
+| `php8.2-fp1.11.3-base` | 8.2 | Base | Production ready (EOL 2026-12-31, upgrade recommended) |
+| `php8.2-fp1.11.3-dev` | 8.2 | Dev | With Xdebug (EOL 2026-12-31, upgrade recommended) |
 | `latest` | 8.4 | Base | Default |
 | `base` | 8.4 | Base | Alias |
 | `dev` | 8.4 | Dev | Alias |
@@ -23,7 +25,7 @@ This guide explains how to use the Magento FrankenPHP Docker images.
 ```yaml
 services:
   app:
-    image: mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-dev
+    image: mohelmrabet/magento-frankenphp:php8.4-fp1.11.3-dev
     environment:
       - USER_ID=1000
       - GROUP_ID=1000
@@ -37,7 +39,7 @@ services:
 ### Production
 
 ```dockerfile
-FROM mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-base
+FROM mohelmrabet/magento-frankenphp:php8.4-fp1.11.3-base
 
 COPY --chown=www-data:www-data . /var/www/html/
 
@@ -50,8 +52,8 @@ RUN bin/magento setup:static-content:deploy -f
 ## Features
 
 ### Base Image
-- ✅ PHP 8.2, 8.3, 8.4
-- ✅ FrankenPHP 1.10.1
+- ✅ PHP 8.2, 8.3, 8.4, 8.5
+- ✅ FrankenPHP 1.11.3
 - ✅ All Magento PHP extensions
 - ✅ Composer 2
 - ✅ OPcache optimized
@@ -75,11 +77,13 @@ bcmath, gd, intl, mbstring, opcache, pdo_mysql, soap, xsl, zip, sockets, ftp, so
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `USER_ID` | `1000` | UID for www-data |
-| `GROUP_ID` | `1000` | GID for www-data |
+| `USER_ID` | `1000` | UID www-data is remapped to at startup (matches host file ownership on bind mounts) |
+| `GROUP_ID` | `1000` | GID www-data is remapped to at startup |
 | `MAGENTO_RUN_MODE` | `developer` | Magento mode |
 | `SERVER_NAME` | `localhost` | Server hostname for SSL |
-| `ENABLE_SSL_DEV` | `true` | Enable self-signed SSL |
+| `ENABLE_SSL_DEV` | `true` | Generate a locally-trusted certificate with mkcert at startup |
+| `CADDY_TLS_CONFIG` | *(auto)* | Set explicitly to skip mkcert and use `internal` or your own `cert key` paths |
+| `CAROOT` | *(mkcert default)* | Path to a shared mkcert CA (see [Configuration](configuration.md#trusted-local-https-mkcert)) so generated certs are trusted by the host |
 
 ## See Also
 

--- a/docs/xdebug.md
+++ b/docs/xdebug.md
@@ -4,7 +4,7 @@ This guide explains how to configure and use Xdebug for debugging your Magento 2
 
 ## Prerequisites
 
-- Use the **development image** (`mohelmrabet/magento-frankenphp:dev` or `php8.4-fp1.10.1-dev`)
+- Use the **development image** (`mohelmrabet/magento-frankenphp:dev` or `php8.4-fp1.11.3-dev`)
 - PHPStorm, VS Code, or another IDE with Xdebug support
 
 ## Default Configuration
@@ -36,7 +36,7 @@ You can customize Xdebug settings using environment variables. These are process
 ```yaml
 services:
   app:
-    image: mohelmrabet/magento-frankenphp:php8.4-fp1.10.1-dev
+    image: mohelmrabet/magento-frankenphp:php8.4-fp1.11.3-dev
     environment:
       XDEBUG_MODE: debug
       XDEBUG_CLIENT_HOST: host.docker.internal

--- a/docs/xdebug.md
+++ b/docs/xdebug.md
@@ -4,7 +4,7 @@ This guide explains how to configure and use Xdebug for debugging your Magento 2
 
 ## Prerequisites
 
-- Use the **development image** (`mohelmrabet/magento-frankenphp:dev` or `php8.4-fp1.11.3-dev`)
+- Use the **development image** (`mohelmrabet/magento-frankenphp:dev` or `php8.4-fp1.12.7-dev`)
 - PHPStorm, VS Code, or another IDE with Xdebug support
 
 ## Default Configuration
@@ -36,7 +36,7 @@ You can customize Xdebug settings using environment variables. These are process
 ```yaml
 services:
   app:
-    image: mohelmrabet/magento-frankenphp:php8.4-fp1.11.3-dev
+    image: mohelmrabet/magento-frankenphp:php8.4-fp1.12.7-dev
     environment:
       XDEBUG_MODE: debug
       XDEBUG_CLIENT_HOST: host.docker.internal


### PR DESCRIPTION
## Summary
- Bump FrankenPHP 1.10.1 -> 1.11.3 (fixes arbitrary file execution and worker-mode session leak CVEs), add PHP 8.5 to the build matrix (Magento 2.4.9 requires 8.4/8.5), keep PHP 8.2 for now but mark it EOL (2026-12-31) in docs.
- Implement the USER_ID/GROUP_ID mapping and mkcert TLS generation in the dev entrypoint that were previously only documented, not implemented: www-data is now actually remapped and privileges dropped via gosu before starting FrankenPHP; a real mkcert certificate is generated at startup with fallback to Caddy's internal TLS.
- Add `bin/setup-ssl` to share the host's mkcert CA with the container so generated certs are trusted by the browser.
- Fix a permission-denied regression on `/config/caddy` caused by dropping root privileges via gosu.
- Tighten the Trivy scan in CI to fail on CRITICAL/HIGH findings instead of always succeeding (`continue-on-error` removed).

## Test plan
- [x] Built dev image (PHP 8.4 + FrankenPHP 1.11.3) locally
- [x] Verified UID/GID remap with custom `USER_ID`/`GROUP_ID` and with defaults (FrankenPHP process confirmed running as the mapped UID via `/proc/1/status`)
- [x] Verified mkcert certificate generation and `https://localhost/health.php` returns 200
- [x] Verified `ENABLE_SSL_DEV=false` fallback to Caddy internal TLS
- [x] `shellcheck` clean on `entrypoint-dev.sh` and `bin/setup-ssl`
- [ ] CI (Docker Build / Tests workflows) to run on this PR