### PR TITLE
Remove unused tags trigger from Docker Build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
 
 env:
   REGISTRY: docker.io


### PR DESCRIPTION
## Summary
- Remove the `tags: v*` push trigger from `.github/workflows/docker.yml` — no `vX.Y.Z` tag was ever pushed to this repo, so it never fired. Image versioning is fully handled by the docker tags generated on every `main` push (e.g. `php8.4-fp1.12.7-base`).
- Also deleted the stray `1.0.0` git tag left over from repo init (no `v` prefix, so it never matched the trigger pattern anyway).

Note: merging this will trigger a full rebuild of all 8 image variants since it touches `docker.yml`, even though the change itself has no effect on the built images.

## Test plan
- [x] N/A — workflow trigger config change only, no image content changed