### PR TITLE
Add apt-get upgrade for OS-level security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,11 @@ ARG FRANKENPHP_VERSION=1.12.7
 FROM dunglas/frankenphp:${FRANKENPHP_VERSION}-php${PHP_VERSION} AS base
 LABEL maintainer="Mohamed El Mrabet <contact@cleatsquad.dev>"
 
-# Combine package installation and cleanup in a single layer
+# Combine package installation and cleanup in a single layer.
+# apt-get upgrade pulls in Debian security patches for packages already in
+# the base frankenphp image (e.g. perl) that a plain install wouldn't touch.
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
       cron \
       libfreetype6-dev \
@@ -100,7 +103,7 @@ FROM base AS dev
 # trivy:ignore:AVD-DS-0002
 USER root
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     git \
     mkcert \
  && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Add `apt-get upgrade -y` after `apt-get update` in both the `base` and `dev` stages, so Debian security patches for packages already present in the upstream `dunglas/frankenphp` base image get pulled in, not just the packages we explicitly `apt-get install`.
- Prompted by Docker Scout flagging OS-level CVEs (e.g. `perl-base`) after activating it on the Docker Hub repo.

## Known limitation
The two `perl` CVEs Scout currently reports (CVE-2026-12087, CVE-2026-13221) are marked **not fixable** by Scout — Debian hasn't published a patched `perl-base` package yet, so this change doesn't resolve those specifically. It's still worth having so any OS package that *does* have an available fix gets it automatically on every rebuild.

Related: most of the CRITICAL/HIGH findings Scout reports are actually Go dependencies compiled into the upstream `frankenphp` binary itself (`golang/stdlib`, `github.com/getkin/kin-openapi`, `google.golang.org/grpc`) — already tracked and explained as false positives by the frankenphp maintainer in [php/frankenphp#2559](https://github.com/php/frankenphp/issues/2559); nothing actionable here until upstream bumps those deps in a future release.

## Test plan
- [x] Built the `base` target locally with the change
- [x] Ran the container, confirmed health check still returns 200
- [x] No permission/startup regressions in logs